### PR TITLE
Remove warnings about variable ambiguity

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,9 +10,9 @@ defmodule FNV.Mixfile do
       app: :fnv,
       version: @version,
       elixir: "~> 1.2",
-      deps: deps,
-      package: package,
-      description: description,
+      deps: deps(),
+      package: package(),
+      description: description(),
       source_url: @project_url,
       homepage_url: @docs_url,
       docs: &docs/0,
@@ -33,7 +33,7 @@ defmodule FNV.Mixfile do
         "GitHub" => @project_url,
         "Docs" => "#{@docs_url}/#{@version}/"
       },
-      files: package_files
+      files: package_files()
     ]
   end
 


### PR DESCRIPTION
PR to remove these warnings:

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /deps/fnv/mix.exs:13

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /deps/fnv/mix.exs:14

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /deps/fnv/mix.exs:15

warning: variable "package_files" does not exist and is being expanded to "package_files()", please use parentheses to remove the ambiguity or change the variable name
  /deps/fnv/mix.exs:36
```